### PR TITLE
[OG-1402] Bump base node image to latest LTS version

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.12.0
+FROM node:14.15.5
 
 RUN apt-get update \
     && apt-get install -y \


### PR DESCRIPTION
@kieferrj @olee2002 I'm thinking we should bump the node version up. It is getting a little dated. The latest version is 15.8.0 these days, but it probably makes sense for us to use the even LTS versions on our base node image.